### PR TITLE
Use all embedding fields

### DIFF
--- a/.configs_sample
+++ b/.configs_sample
@@ -9,6 +9,7 @@ apipassword: password
 embedding_api_host: api.host.url:port
 embedding_api_user: USER
 embedding_api_password: PW
+embedding_api_version: v2
 
 # Organization / Location specific settings:
 contact_email: contact@email.com

--- a/.configs_sample
+++ b/.configs_sample
@@ -9,7 +9,7 @@ apipassword: password
 embedding_api_host: api.host.url:port
 embedding_api_user: USER
 embedding_api_password: PW
-embedding_api_version: v2
+embedding_api_version: v1
 
 # Organization / Location specific settings:
 contact_email: contact@email.com

--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -174,6 +174,8 @@ embedding_search_body <- function(query,
                                   api_password,
                                   vector_field = 'source_title_vector') {
   vector = get_embedding_vector(query, api_url, api_user, api_password)
+  if (is.null(vector)) { return('') }
+
   vector_str = paste0("[", paste0(vector, collapse = ", "), "]")
 
   # https://www.elastic.co/guide/en/elasticsearch/reference/7.3/query-dsl-script-score-query.html#vector-functions
@@ -355,6 +357,12 @@ get_embedding_vector <- function(query,
     paste0("/embeddings_api/", api_version, "/embed_query?query=", query) %>%
     httr::GET(authenticate(api_user, api_password)) %>%
     httr::content()
+
+  if ("error" %in% names(res)) {
+    write(paste0("ERROR From API in get_embedding_vector: ", as.character(res)), stderr())
+    return(NULL)
+  }
+
   unlist(res$embedding_vector)
 }
 

--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -184,7 +184,6 @@ embedding_search_body <- function(query,
                                   api_version,
                                   vector_fields_to_search) {
   vector = get_embedding_vector(query, api_url, api_user, api_password, api_version)
-  if (is.null(vector)) { return('') }
 
   vector_str = paste0("[", paste0(vector, collapse = ", "), "]")
 
@@ -381,17 +380,17 @@ get_embedding_vector <- function(query,
                                  api_password,
                                  api_version) {
   query = URLencode(query)
-  res = api_url %>%
+  response = api_url %>%
     paste0("/embeddings_api/", api_version, "/embed_query?query=", query) %>%
-    httr::GET(authenticate(api_user, api_password)) %>%
-    httr::content()
-
-  if ("error" %in% names(res)) {
-    write(paste0("ERROR From API in get_embedding_vector: ", as.character(res)), stderr())
-    return(NULL)
+    httr::GET(authenticate(api_user, api_password)) 
+    
+  if (response$status != 200) { 
+    stop(paste0("ERROR From API at ", api_url, " with user ", api_user, " in get_embedding_vector(): ", as.character(response))) 
   }
 
-  unlist(res$embedding_vector)
+  content = httr::content(response)
+
+  unlist(content$embedding_vector)  
 }
 
 parse_hits <- function(es_results, index_to_db_map) {


### PR DESCRIPTION
Previously, we only searched the embedding vector for the document title. Now, searching all 3 vector fields, if they exist, and they've been selected to be searched. 

Also parameterized the API version in the `.configs` file, which allows us to be backward compatible. 