### PR TITLE
remove coe_td filter on indices

### DIFF
--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -96,8 +96,7 @@ index_to_alias_mapping <- function(es, alias_names) {
   mapping = elastic::aliases_get(es, index = alias_names)
 
   mapping_df = tibble::enframe(mapping, name = "index_name") %>%
-    tidyr::unnest_wider(value) %>%
-    filter(str_detect(index_name, "coe_td_"))
+    tidyr::unnest_wider(value)
 
   if (!all(is.na(mapping_df$aliases))) { 
     mapping_df = mapping_df %>%


### PR DESCRIPTION
simple change to remove the requirement that indices follow the coe_td_* naming convention. This is our old approach, and is no longer required