### PR TITLE
Add option to change result sort order

### DIFF
--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -159,29 +159,27 @@ search_body <- function(query,
     # min_score = 0.55 # This suggests using at least 0.5 for Doc2Vec: https://radimrehurek.com/gensim/auto_examples/howtos/run_doc2vec_imdb.html
     min_score = 0.35 # FastText needs a lower min_score
     vector_fields = paste0(search_fields, "_vector")
-    embedding_search_body(query, 
-                          fields_str, 
+    embedding_search_body(query,
+                          vector_fields, 
                           filter_str, 
                           min_score, 
                           get_configs()$embedding_api_host, 
                           get_configs()$embedding_api_user, 
                           get_configs()$embedding_api_password, 
-                          get_configs()$embedding_api_version,
-                          vector_fields)
+                          get_configs()$embedding_api_version)
   } else {
     standard_search_body(query, fields_str, filter_str, min_score)
   }
 }
 
 embedding_search_body <- function(query,
-                                  fields_str,
+                                  vector_fields_to_search,
                                   filter_str,
                                   min_score,
                                   api_url,
                                   api_user,
                                   api_password,
-                                  api_version,
-                                  vector_fields_to_search) {
+                                  api_version) {
   vector = get_embedding_vector(query, api_url, api_user, api_password, api_version)
 
   vector_str = paste0("[", paste0(vector, collapse = ", "), "]")
@@ -341,6 +339,7 @@ query_text_depot <- function(query_info = NULL,
   max_date = query_info$max_date
   min_sentiment = query_info$min_sentiment
   max_sentiment = query_info$max_sentiment
+  sort_by = query_info$sort_by
   use_embeddings = query_info$use_embeddings
   query_search <- search_body(
     query = query_str,
@@ -353,12 +352,18 @@ query_text_depot <- function(query_info = NULL,
     use_embedding_search = use_embeddings
   )
 
+  if (is.null(sort_by)) { sort_by = "score" }
+  sort_json = case_when(sort_by == "score" ~ '"sort": [ "_score" ]',
+                        sort_by == "date_asc" ~ '"sort": [ {"date": "asc"} ]',
+                        sort_by == "date_desc" ~ '"sort": [ {"date": "desc"} ]',
+                        TRUE ~ '"sort": [ "_score" ]')
+
   # if part of query is not defined, it will be default NULL value, and that is elegantly handled by combine_query:
   query <- combine_query(query_search,
                          aggregates_json,
                          source_json,
-                         highlights_json
-  )
+                         highlights_json,
+                         sort_json)
 
   results <- elastic::Search(conn = conn,
                              index = index,

--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -372,7 +372,6 @@ query_text_depot <- function(query_info = NULL,
                              from = from,
                              size = size
   )
-  print(paste("@@@@@@@",results))
 
   if (results$`_shards`$failed > 0) { return(paste0("Error! Shard Failed! ", paste(results$`_shards`$failures, collapse = "; "))) }
 

--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -354,8 +354,8 @@ query_text_depot <- function(query_info = NULL,
 
   if (is.null(sort_by)) { sort_by = "score" }
   sort_json = case_when(sort_by == "score" ~ '"sort": [ "_score" ]',
-                        sort_by == "date_asc" ~ '"sort": [ {"date": "asc"} ]',
-                        sort_by == "date_desc" ~ '"sort": [ {"date": "desc"} ]',
+                        sort_by == "date_asc" ~ '"sort": [ {"date":{"order":"asc"}} ,{"_score":{"order":"desc"}}]',
+                        sort_by == "date_desc" ~ '"sort": [ {"date": {"order":"desc"}},{"_score":{"order":"desc"}} ]',
                         TRUE ~ '"sort": [ "_score" ]')
 
   # if part of query is not defined, it will be default NULL value, and that is elegantly handled by combine_query:
@@ -372,6 +372,7 @@ query_text_depot <- function(query_info = NULL,
                              from = from,
                              size = size
   )
+  print(paste("@@@@@@@",results))
 
   if (results$`_shards`$failed > 0) { return(paste0("Error! Shard Failed! ", paste(results$`_shards`$failures, collapse = "; "))) }
 

--- a/search_bar_module.R
+++ b/search_bar_module.R
@@ -28,6 +28,12 @@ searchBarUI <- function(id){
                                                                   no = icon("remove", lib = "glyphicon"))),
               uiOutput(ns("date_range_ui"), style = "padding-left: 10px"),
               uiOutput(ns("sentiment_range_ui")),
+              shinyWidgets::radioGroupButtons(ns("sort_by"),
+                                              label = "Sort Results By",
+                                              choices = c("Search Score" = "score", 
+                                                          "Date (Oldest First)" = "date_asc", 
+                                                          "Date (Newest First)" = "date_desc"),
+                                              status = "success"), # selected = 
               uiOutput(ns("data_source_ui")),
 
               # Only turn on AI search if we've specified an API Host:
@@ -127,7 +133,6 @@ searchBar <- function(input, output, session,
       start = min,
       end = max)
   })
-
   
   sentiment_stats <- reactive({
     stats_for_field(es_connection, data_set_info()$alias_name, "sentiment_polarity",numeric = TRUE)
@@ -227,6 +232,7 @@ searchBar <- function(input, output, session,
          max_date = selected_date_range()[2],
          min_sentiment = selected_sentiment_range()[1],
          max_sentiment = selected_sentiment_range()[2],
+         sort_by = input$sort_by,
          num_hits = sum(aggregations()$counts_by_index$doc_count),
          use_embeddings = use_embeddings_setting())
   })

--- a/search_bar_module.R
+++ b/search_bar_module.R
@@ -33,7 +33,8 @@ searchBarUI <- function(id){
                                               choices = c("Search Score" = "score", 
                                                           "Date (Oldest First)" = "date_asc", 
                                                           "Date (Newest First)" = "date_desc"),
-                                              status = "success"), # selected = 
+                                              status = "success",
+                                              selected = "score"),
               uiOutput(ns("data_source_ui")),
 
               # Only turn on AI search if we've specified an API Host:

--- a/search_results_table_module.R
+++ b/search_results_table_module.R
@@ -142,8 +142,7 @@ searchResultsTable <- function(input, output, session,
     req(hits)
     req(nrow(hits) > 0)
 
-    hits %>%
-      arrange(desc(similarity))
+    hits
   })
 
   output$column_picker <- renderUI({


### PR DESCRIPTION
Several users have said they would find value in sorting the search results by date (e.g. finding the oldest or newest documents). This PR adds the options to sort search results by date (ascending) and date (descending):

<img width="1262" alt="Fullscreen_2023-01-24__10_45_AM" src="https://user-images.githubusercontent.com/490216/214388272-c90fc4bb-fbd5-46b2-ac9d-eb51205aaf8c.png">
