### PR TITLE
Fix and update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax = docker/dockerfile:1.0-experimental # https://docs.docker.com/develop/develop-images/build_enhancements/
-FROM rocker/r-ver:4.2.1
+FROM rocker/r-ver:4.3.0
 
 RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update \
   && apt-get install -y \
@@ -7,16 +7,23 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update \
   libudunits2-dev \
   libxt6 \
   xdg-utils \
+  # following 3 libraries were needed when we switched to installing cran 
+  # libraries from source (because arm binaries not available)
+  # may be able to remove when arm cran binaries become available
+  libharfbuzz-dev \
+  libfribidi-dev \
+  libgit2-dev \
   && rm -rf /var/lib/apt/lists/*
 
 
 # Freezing packages:
+# get from https://packagemanager.rstudio.com/client/#/repos/1/overview
 ARG TARGETPLATFORM
 RUN case ${TARGETPLATFORM} in \
   "linux/amd64") \
-  echo "options(repos = c(REPO_NAME = 'https://packagemanager.rstudio.com/cran/__linux__/jammy/2022-04-22'))" >> $R_HOME/etc/Rprofile.site ;; \
+  echo "options(repos = c(REPO_NAME = 'https://packagemanager.rstudio.com/cran/__linux__/jammy/2023-05-30'))" >> $R_HOME/etc/Rprofile.site ;; \
   "linux/arm64") \
-  echo "options(repos = c(REPO_NAME = 'https://packagemanager.rstudio.com/cran/2022-04-22'))" >> $R_HOME/etc/Rprofile.site ;; \
+  echo "options(repos = c(REPO_NAME = 'https://packagemanager.rstudio.com/cran/2023-05-30'))" >> $R_HOME/etc/Rprofile.site ;; \
 esac
 
 RUN R -e "options(warn = 2); install.packages(c('assertthat', \


### PR DESCRIPTION
MRAN cran mirror is being decommissioned. This PR changes to use Rstudio package manager. While making this fix, also took the opportunity to update the FROM image and the date for the CRAN snapshot. Seems to be working locally.