### PR TITLE
Fix index issue

### DIFF
--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -100,7 +100,7 @@ index_to_alias_mapping <- function(es, alias_names) {
 
   if (!all(is.na(mapping_df$aliases))) { 
     mapping_df = mapping_df %>%
-      tidyr::unnest_longer(aliases, indices_to = "alias_name") %>%
+      tidyr::unnest_longer(aliases, indices_to = "alias_name", keep_empty = TRUE) %>%
       select(-aliases) %>%
       mutate(alias_name = dplyr::coalesce(alias_name, index_name)) # use index name if alias name not present
   } else {


### PR DESCRIPTION
Some combinations of `default_index_aliases` in the `.configs` file cause errors in the dashboard. That list can contain indexes or aliases. However, if the list contains a mix of aliases and indexes without an alias assigned, the dashboard throws an error. 

For testing, I used combinations of `edmonton_tweets` (an alias), `coe_td_insight_surveys_1` (an index without an alias) and `coe_td_insight_surveys_2` (an index with an alias). 

These settings worked fine:
* default_index_aliases: ['edmonton_tweets']
* default_index_aliases: ['coe_td_insight_surveys_1']
* default_index_aliases: ['coe_td_insight_surveys_2']
* default_index_aliases: ['edmonton_tweets', 'coe_td_insight_surveys_2']

However, this one failed when running the application: (A mix of alias and index that has no assigned alias):
* default_index_aliases: ['edmonton_tweets', 'coe_td_insight_surveys_1']

After making the change in this PR, all above settings worked. 