### PR TITLE
fix error with left_join on colors

### DIFF
--- a/sentiment_neighbourhoods_module.R
+++ b/sentiment_neighbourhoods_module.R
@@ -78,7 +78,7 @@ mapPlot <- function(input, output, session,
     aggregations = query_text_depot(query_info = query_info(),
                                     aggregates_json = sentimentNeighbourhoodsQuery())
     aggregations = parse_aggregates(es_results = aggregations)
-          
+
     bbox = sf::st_bbox(neighbourhoods)
     min.lat = as.numeric(bbox$ymin)
     max.lat = as.numeric(bbox$ymax)
@@ -114,17 +114,19 @@ mapPlot <- function(input, output, session,
 
       pal = colorNumeric(palette = "Blues", domain = hoods_df$doc_count, reverse = FALSE)
       
-      colours = get_sentiment_colourmap()
-      
       hoods_df$label = ifelse(!is.na(hoods_df$avg_sentiment),
                               as.character(cut(hoods_df$avg_sentiment, 
-                                              breaks = c(colour_map$lower, Inf), 
-                                              labels = colour_map$label, 
-                                              include.lowest = TRUE, 
-                                              right = TRUE)),
+                                               breaks = c(colour_map$lower, Inf), 
+                                               labels = colour_map$label, 
+                                               include.lowest = TRUE, 
+                                               right = TRUE)),
                               NA)
+      # Remove repeats of "NEUTRAL" so join doesnt cause issues:
+      colours = colour_map %>% 
+        select(colour, legend_text_colour, label) %>% 
+        distinct()
       hoods_df = dplyr::left_join(hoods_df, colours, by = c("label" = "label"))
-      
+
       if (selected == "Sentiment") {
         map = map %>% 
           addPolygons(
@@ -192,7 +194,7 @@ mapPlot <- function(input, output, session,
   })
   
   output$sentiment_colour_scale <- renderPlot({
-    colour_map <- get_sentiment_colourmap()
+    colour_map = get_sentiment_colourmap()
     sentimentLegendPlot(colour_mapping = colour_map)
   })
 }


### PR DESCRIPTION
Fixing error in the neighbourhoods map. The results data was being joined to the colours data frame which looked like this:

![Fullscreen_2023-07-06__3_01_PM](https://github.com/CityofEdmonton/text_depot/assets/490216/7b3862e2-ebd1-4bcb-8d06-63fa94f1dea7)

So any result with a "Neutral" label would result in multiple matches. Used a collapsed version of the colours data frame to avoid this repetition. 