### PR TITLE
Fix stats for empty indexes

### DIFF
--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -308,10 +308,14 @@ stats_for_field <- function(conn, index, field, numeric = FALSE) {
   result <- elastic::Search(conn, index = index, body = aggs, size = 0)
 
   if (numeric) {
-    return(list(min = result$aggregations$fieldstats$min,
-                max = result$aggregations$fieldstats$max,
-                avg = result$aggregations$fieldstats$avg,
-                sum = result$aggregations$fieldstats$sum))
+    min = ifelse(is.null(result$aggregations$fieldstats$min), NA, result$aggregations$fieldstats$min)
+    max = ifelse(is.null(result$aggregations$fieldstats$max), NA, result$aggregations$fieldstats$max)
+    avg = ifelse(is.null(result$aggregations$fieldstats$avg), NA, result$aggregations$fieldstats$avg)
+    sum = ifelse(is.null(result$aggregations$fieldstats$sum), NA, result$aggregations$fieldstats$sum)
+    return(list(min = min,
+                max = max,
+                avg = avg,
+                sum = sum))
   } else {
     return(list(min = result$aggregations$fieldstats$min_as_string,
                 max = result$aggregations$fieldstats$max_as_string,


### PR DESCRIPTION
The "Additional Information" window showed an error when one of the Elastic Search indexes contains no documents. Fixed the function to handle this case, and display `NA` in columns for an empty index. 

Previously, the stats function would return `NULL` for stats queries on an empty index, but R handles this in a weird way, not allowing construction of the overall dataframe containing the stats. Using `NA` instead fixes this issue. 

**Before:**
![Cursor_and_Text_Depot_-_Default](https://github.com/CityofEdmonton/text_depot/assets/490216/30aa56df-907b-4905-b58d-67d330c659f2)

**After:**
![Cursor_and_localhost_8080](https://github.com/CityofEdmonton/text_depot/assets/490216/b3e36982-4964-4043-b46d-4758485e8922)
