### PR TITLE
Update Packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && apt-get -y update \
   && rm -rf /var/lib/apt/lists/*
 
 # Freezing packages. Get available URLs at https://packagemanager.posit.co/client/#/repos/cran/setup
-ARG PACKAGEDATE=2023-10-23
+ARG PACKAGEDATE=2024-09-01
 ARG TARGETPLATFORM
 RUN case ${TARGETPLATFORM} in \
   "linux/amd64") \
@@ -25,10 +25,6 @@ RUN case ${TARGETPLATFORM} in \
   "linux/arm64") \
   echo "options(repos = c(REPO_NAME = 'https://packagemanager.posit.co/cran/${PACKAGEDATE}'))" >> $R_HOME/etc/Rprofile.site ;; \
 esac
-
-# https://github.com/daattali/shinycssloaders/issues/82
-RUN R -e "options(warn = 2); install.packages('devtools', Ncpus = max(1L, parallel::detectCores()))"
-RUN R -e "options(warn = 2); devtools::install_github('daattali/shinycssloaders')"
 
 RUN R -e "options(warn = 2); install.packages(c('assertthat', \
   'data.table', \
@@ -48,7 +44,7 @@ RUN R -e "options(warn = 2); install.packages(c('assertthat', \
   'promises', \
   'rmarkdown', \
   'shiny', \
-  # 'shinycssloaders', \
+  'shinycssloaders', \
   'shinydashboard', \
   'shinyjs', \
   'shinyWidgets', \

--- a/dashboard_utils.R
+++ b/dashboard_utils.R
@@ -387,7 +387,7 @@ get_document_summary <- function(query,
                                  api_password) {
   body = list(query = query, max_summary_length = 150)
   response = api_url %>%
-    paste0("/summarize") %>%
+    paste0("summarize") %>%
     httr::POST(authenticate(api_user, api_password), body = body, encode = "json") 
     
   if (response$status != 200) { 


### PR DESCRIPTION
Previously, we installed the `shinycssloaders` packages manually in the Dockerfile from github, because the CRAN version had an [issue](https://github.com/daattali/shinycssloaders/issues/82). This has since been resolved, and pushed to CRAN.

This PR updates the package lock date. This caused an issue with text summarization (an extra slash in the URL for the request), and that is fixed as well. 